### PR TITLE
add key binding entries for the gamepad keys of the OLPC XO-1.

### DIFF
--- a/input.h
+++ b/input.h
@@ -105,6 +105,15 @@
 #define K_JOYRIGHT 0x1cc
 #define K_JOYLEFT 0x1cd
 
+#define K_XO_CHECK 0x141
+#define K_XO_DOWN 0x142
+#define K_XO_CROSS 0x143
+#define K_XO_LEFT 0x144
+#define K_XO_RIGHT 0x146
+#define K_XO_BOX 0x147
+#define K_XO_UP 0x148
+#define K_XO_CIRCLE 0x149
+
 #define MAX_KEYS 0x200
 
 typedef struct keytable_s

--- a/input.h
+++ b/input.h
@@ -105,15 +105,6 @@
 #define K_JOYRIGHT 0x1cc
 #define K_JOYLEFT 0x1cd
 
-#define K_XO_CHECK 0x141
-#define K_XO_DOWN 0x142
-#define K_XO_CROSS 0x143
-#define K_XO_LEFT 0x144
-#define K_XO_RIGHT 0x146
-#define K_XO_BOX 0x147
-#define K_XO_UP 0x148
-#define K_XO_CIRCLE 0x149
-
 #define MAX_KEYS 0x200
 
 typedef struct keytable_s

--- a/keytable.c
+++ b/keytable.c
@@ -125,6 +125,15 @@ keytable_t keytable[] =
 	{ "joy14", K_JOY14 },
 	{ "joy15", K_JOY15 },
 
+	{ "xocheck",  321 },
+	{ "xodown",   322 },
+	{ "xocross",  323 },
+	{ "xoleft",   324 },
+	{ "xoright",  326 },
+	{ "xobox",    327 },
+	{ "xoup",     328 },
+	{ "xocircle", 329 },
+
 	{ NULL, 0 }
 };
 

--- a/keytable.c
+++ b/keytable.c
@@ -125,14 +125,14 @@ keytable_t keytable[] =
 	{ "joy14", K_JOY14 },
 	{ "joy15", K_JOY15 },
 
-	{ "xocheck", K_XO_CHECK },
-	{ "xodown", K_XO_DOWN },
-	{ "xocross", K_XO_CROSS },
-	{ "xoleft", K_XO_LEFT },
-	{ "xoright", K_XO_RIGHT },
-	{ "xobox", K_XO_BOX },
-	{ "xoup", K_XO_UP },
-	{ "xocircle", K_XO_CIRCLE },
+	{ "xocheck", K_NUM1 },
+	{ "xodown", K_NUM2 },
+	{ "xocross", K_NUM3 },
+	{ "xoleft", K_NUM4 },
+	{ "xoright", K_NUM6 },
+	{ "xobox", K_NUM7 },
+	{ "xoup", K_NUM8 },
+	{ "xocircle", K_NUM9 },
 
 	{ NULL, 0 }
 };

--- a/keytable.c
+++ b/keytable.c
@@ -125,14 +125,14 @@ keytable_t keytable[] =
 	{ "joy14", K_JOY14 },
 	{ "joy15", K_JOY15 },
 
-	{ "xocheck",  321 },
-	{ "xodown",   322 },
-	{ "xocross",  323 },
-	{ "xoleft",   324 },
-	{ "xoright",  326 },
-	{ "xobox",    327 },
-	{ "xoup",     328 },
-	{ "xocircle", 329 },
+	{ "xocheck", K_XO_CHECK },
+	{ "xodown", K_XO_DOWN },
+	{ "xocross", K_XO_CROSS },
+	{ "xoleft", K_XO_LEFT },
+	{ "xoright", K_XO_RIGHT },
+	{ "xobox", K_XO_BOX },
+	{ "xoup", K_XO_UP },
+	{ "xocircle", K_XO_CIRCLE },
 
 	{ NULL, 0 }
 };


### PR DESCRIPTION
A few weeks ago I obtained an [OLPC XO-1](https://en.wikipedia.org/wiki/OLPC_XO), a low-power, ruggedized i686 laptop, and I've been working to adapt applications to run on it nicely. GnuBoy builds easily and runs great, but the [Game Controller](http://wiki.laptop.org/go/Game_controller) buttons on the XO-1 use unusual scancodes. This patch adds appropriately named keys for these scancodes so that a `gnuboy.rc` file can be used to produce bindings for them.

I don't have access to any of the newer hardware revisions of the XO, but I expect these scancodes to be consistent in them as well.

I recognize that this functionality is only helpful to a _very tiny_ group of users, so I won't be offended if you reject this pull request.